### PR TITLE
Fix importOnce variable scope bug.

### DIFF
--- a/sass/base/utils/_system.scss
+++ b/sass/base/utils/_system.scss
@@ -8,7 +8,7 @@
 $modules: () !default;
 @mixin importOnce($uniqeRef) {
   @if not index($modules, $uniqeRef) {
-    $modules: append($modules, $uniqeRef);
+    $modules: append($modules, $uniqeRef) !global;
     @content;
   }
 }


### PR DESCRIPTION
Without !global, the $modules variable is empty on each call. Preventing enforcement of the import once rule.

Fixes issue #13 