### PR TITLE
Remove redundant box-sizing browser prefixes

### DIFF
--- a/sass/base/project/_globals.scss
+++ b/sass/base/project/_globals.scss
@@ -5,8 +5,6 @@
   *,
   :before,
   :after {
-    -moz-box-sizing: border-box;
-    -webkit-box-sizing: border-box;
     box-sizing: border-box;
   }
 


### PR DESCRIPTION
As you can see here: http://caniuse.com/#search=box-sizing you no longer need to specify browser-prefixes for the box-sizing property. To prevent code clutter (admittedly on microscopic level) but also to educate people about this, imo it is better to remove it.
